### PR TITLE
Apply updates for yarn-api-client changes (and lint)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -105,3 +105,6 @@ venv.bak/
 
 # mypy
 .mypy_cache/
+
+# mac - desktop services meta-files
+.DS_Store

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,23 @@
+[bdist_wheel]
+
+[metadata]
+description-file=README.md
+license_file=LICENSE
+
+[flake8]
+# References:
+# https://flake8.readthedocs.io/en/latest/user/configuration.html
+# https://flake8.readthedocs.io/en/latest/user/error-codes.html
+exclude = __init__.py
+ignore =
+    # Import formatting
+    E4,
+    # Comparing types instead of isinstance
+    E721,
+    # Assigning lambda expression
+    E731,
+    # Ambiguous variable names
+    E741,
+    # Allow breaks after binary operators
+    W504
+max-line-length = 120

--- a/setup.py
+++ b/setup.py
@@ -64,7 +64,7 @@ setup_args = dict(
         'remote_kernel_provider',
         'jupyter_kernel_mgmt',
         'entrypoints',
-        'yarn-api-client>=0.3.3',
+        'yarn-api-client>=0.3.5',
     ],
     extras_require   = {
         'test': ['mock', 'pytest'],

--- a/tests/test_yarn_kernel_provider.py
+++ b/tests/test_yarn_kernel_provider.py
@@ -5,10 +5,6 @@
 
 
 import unittest
-from click.testing import CliRunner
-
-from yarn_kernel_provider import provider
-from yarn_kernel_provider import cli
 
 
 class TestYarn_kernel_provider(unittest.TestCase):
@@ -19,16 +15,3 @@ class TestYarn_kernel_provider(unittest.TestCase):
 
     def tearDown(self):
         """Tear down test fixtures, if any."""
-
-    def test_000_something(self):
-        """Test something."""
-
-    def test_command_line_interface(self):
-        """Test the CLI."""
-        runner = CliRunner()
-        result = runner.invoke(cli.main)
-        assert result.exit_code == 0
-        assert 'yarn_kernel_provider.cli.main' in result.output
-        help_result = runner.invoke(cli.main, ['--help'])
-        assert help_result.exit_code == 0
-        assert '--help  Show this message and exit.' in help_result.output

--- a/yarn_kernel_provider/_version.py
+++ b/yarn_kernel_provider/_version.py
@@ -1,3 +1,2 @@
 version_info = (0, 1, 0, 'dev0')
 __version__ = '.'.join(map(str, version_info))
-

--- a/yarn_kernel_provider/provider.py
+++ b/yarn_kernel_provider/provider.py
@@ -6,5 +6,5 @@ from remote_kernel_provider.provider import RemoteKernelProviderBase
 class YarnKernelProvider(RemoteKernelProviderBase):
 
     id = 'yarn'
-    kernel_file  = 'yarn_kernel.json'
+    kernel_file = 'yarn_kernel.json'
     lifecycle_manager_classes = ['yarn_kernel_provider.yarn.YarnKernelLifecycleManager']

--- a/yarn_kernel_provider/yarn.py
+++ b/yarn_kernel_provider/yarn.py
@@ -36,26 +36,37 @@ class YarnKernelLifecycleManager(RemoteKernelLifecycleManager):
         self.rm_addr = None
         self.yarn_endpoint \
             = lifecycle_config.get('yarn_endpoint',
-                               kernel_manager.app_config.get('yarn_endpoint', "localhost"))  # TODO - default val
+                                   kernel_manager.app_config.get('yarn_endpoint'))
+        self.alt_yarn_endpoint \
+            = lifecycle_config.get('alt_yarn_endpoint',
+                                   kernel_manager.app_config.get('alt_yarn_endpoint'))
+
         self.yarn_endpoint_security_enabled \
-            = lifecycle_config.get('yarn_endpoint_security_enabled',  # TODO - default val
+            = lifecycle_config.get('yarn_endpoint_security_enabled',
                                    kernel_manager.app_config.get('yarn_endpoint_security_enabled', False))
 
-        yarn_master = None
-        yarn_port = None
+        yarn_master = alt_yarn_master = None
+        yarn_port = alt_yarn_port = None
         if self.yarn_endpoint:
             yarn_url = urlparse(self.yarn_endpoint)
             yarn_master = yarn_url.hostname
             yarn_port = yarn_url.port
+            # Only check alternate if "primary" is set.
+            if self.alt_yarn_endpoint:
+                alt_yarn_url = urlparse(self.alt_yarn_endpoint)
+                alt_yarn_master = alt_yarn_url.hostname
+                alt_yarn_port = alt_yarn_url.port
 
         self.resource_mgr = ResourceManager(address=yarn_master,
                                             port=yarn_port,
+                                            alt_address=alt_yarn_master,
+                                            alt_port=alt_yarn_port,
                                             kerberos_enabled=self.yarn_endpoint_security_enabled)
 
-        # Temporary until yarn-api-client can be extended to return host-port info when yarn_master is None.
-        self.rm_addr = yarn_master + ':' + str(yarn_port) if yarn_master is not None else '(see yarn-site.xml)'
+        host, port = self.resource_mgr.get_active_host_port()
+        self.rm_addr = host + ':' + str(port)
 
-# TODO - fix wait time - should just add member to k-m.
+        # TODO - fix wait time - should just add member to k-m.
         # YARN applications tend to take longer than the default 5 second wait time.  Rather than
         # require a command-line option for those using YARN, we'll adjust based on a local env that
         # defaults to 15 seconds.  Note: we'll only adjust if the current wait time is shorter than


### PR DESCRIPTION
Discovered that yarn-api-client interaction was using an older version.  This PR updates to the current yarn-api-client.  It also includes various changes to address lint (flake8) issues.